### PR TITLE
Parse attribute value, unit, and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Outputs:
 The current status of the device is populated when the coroutine `status.refresh()` is called.  The DeviceStatus class represents the current values of the capabilities and provides several normalized property accessors.
 ```pythonstub
     await device.status.refresh()    
-    print(device.status.attributes)
+    print(device.status.values)
     print(device.status.switch)
     print(device.status.level)
 ```

--- a/pysmartthings/__init__.py
+++ b/pysmartthings/__init__.py
@@ -14,8 +14,8 @@ from .errors import APIErrorDetail, APIInvalidGrant, APIResponseError
 from .installedapp import (
     InstalledApp, InstalledAppEntity, InstalledAppStatus, InstalledAppType)
 from .location import Location, LocationEntity
-from .room import Room, RoomEntity
 from .oauthtoken import OAuthToken
+from .room import Room, RoomEntity
 from .scene import Scene, SceneEntity
 from .smartthings import SmartThings
 from .subscription import SourceType, Subscription, SubscriptionEntity

--- a/pysmartthings/const.py
+++ b/pysmartthings/const.py
@@ -1,4 +1,4 @@
 """Define consts for the pysmartthings package."""
 
 __title__ = "pysmartthings"
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -456,6 +456,45 @@ class TestDeviceStatus:
         assert status.components['bottomButton'].level == 50
 
     @staticmethod
+    async def test_values():
+        """Test the values property."""
+        # Arrange
+        data = get_json('device_status.json')
+        status = DeviceStatus(None, DEVICE_ID, data)
+        # Act/Assert
+        assert status.values == {
+            'button': None,
+            'numberOfButtons': None,
+            'supportedButtonValues': None,
+            'indicatorStatus': 'when off',
+            'switch': 'on',
+            'checkInterval': 1920,
+            'healthStatus': None,
+            'DeviceWatch-DeviceStatus': None,
+            'level': 100
+        }
+
+    @staticmethod
+    async def test_attributes():
+        """Test the attributes property."""
+        # Arrange
+        data = get_json('device_status.json')
+        status = DeviceStatus(None, DEVICE_ID, data)
+        # Act/Assert
+        assert status.attributes == {
+            'button': (None, None, None),
+            'numberOfButtons': (None, None, None),
+            'supportedButtonValues': (None, None, None),
+            'indicatorStatus': ('when off', None, None),
+            'switch': ('on', None, None),
+            'checkInterval': (1920, 's', {"protocol": "zwave",
+                                          "hubHardwareId": "000F"}),
+            'healthStatus': (None, None, None),
+            'DeviceWatch-DeviceStatus': (None, None, None),
+            'level': (100, '%', None)
+        }
+
+    @staticmethod
     @pytest.mark.asyncio
     async def test_refresh(api):
         """Tests the refresh method."""
@@ -565,8 +604,8 @@ class TestDeviceStatus:
         """Tests the is_on method."""
         # Arrange
         status = DeviceStatus(None, device_id=DEVICE_ID)
-        status.attributes[Attribute.acceleration] = 'active'
-        status.attributes[Attribute.level] = 100
+        status.update_attribute_value(Attribute.acceleration, 'active')
+        status.level = 100
         # Act/Assert
         assert status.is_on(Attribute.acceleration)
         assert status.is_on(Attribute.level)


### PR DESCRIPTION
## Description:
**BREAKING CHANGE**
- `DeviceStatus` now parses attribute value, unit, and data as a tuple into the `attributes` property.  `values` property introduced to contain only the attribute-to-value mapping.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
  - [X] `README.MD` updated (if necessary)