### PR TITLE
Fix OAuthToken refresh

### DIFF
--- a/pysmartthings/const.py
+++ b/pysmartthings/const.py
@@ -1,4 +1,4 @@
 """Define consts for the pysmartthings package."""
 
 __title__ = "pysmartthings"
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/pysmartthings/oauthtoken.py
+++ b/pysmartthings/oauthtoken.py
@@ -39,8 +39,8 @@ class OAuthToken:
 
     async def refresh(self, client_id: str, client_secret: str):
         """Refresh the auth and refresh tokens."""
-        data = await self._api.generate_tokens(self._refresh_token, client_id,
-                                               client_secret)
+        data = await self._api.generate_tokens(client_id, client_secret,
+                                               self._refresh_token)
         if data:
             self.apply_data(data)
 


### PR DESCRIPTION
## Description:
Fix an issue with `OAuthToken.refresh(...)` where the parameters were passed to the underlying API in the wrong order.  Bump version for release.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.