### PR TITLE
v0.6.4

### DIFF
--- a/lint.cmd
+++ b/lint.cmd
@@ -1,5 +1,5 @@
 @echo off
-pip install isort --quiet
+pip install isort --quiet --upgrade
 isort tests pysmartthings --recursive
 pip install -r test-requirements.txt --quiet
 pylint tests pysmartthings

--- a/pysmartthings/capability.py
+++ b/pysmartthings/capability.py
@@ -22,6 +22,7 @@ CAPABILITIES_TO_ATTRIBUTES = {
     'colorControl': ['color', 'hue', 'saturation'],
     'colorTemperature': ['colorTemperature'],
     'contactSensor': ['contact'],
+    'demandResponseLoadControl': ['drlcStatus'],
     'dishwasherMode': ['dishwasherMode'],
     'dishwasherOperatingState': ['machineState', 'supportedMachineStates',
                                  'dishwasherJobState', 'completionTime'],
@@ -33,6 +34,7 @@ CAPABILITIES_TO_ATTRIBUTES = {
     'energyMeter': ['energy'],
     'equivalentCarbonDioxideMeasurement':
         ['equivalentCarbonDioxideMeasurement'],
+    'execute': ['data'],
     'fanSpeed': ['fanSpeed'],
     'filterStatus': ['filterStatus'],
     'formaldehydeMeasurement': ['formaldehydeLevel'],
@@ -45,12 +47,15 @@ CAPABILITIES_TO_ATTRIBUTES = {
     'mediaPlaybackShuffle': ['playbackShuffle'],
     'mediaPlayback': ['playbackStatus', 'supportedPlaybackCommands'],
     'motionSensor': ['motion'],
+    'ocf': ['st', 'mnfv', 'mndt', 'mnhw', 'di', 'mnsl', 'dmv', 'n', 'vid',
+            'mnmo', 'mnmn', 'mnml', 'mnpv', 'mnos', 'pi', 'icv'],
     'odorSensor': ['odorLevel'],
     'ovenMode': ['ovenMode'],
     'ovenOperatingState': ['machineState', 'supportedMachineStates',
                            'ovenJobState', 'completionTime', 'operationTime',
                            'progress'],
     'ovenSetpoint': ['ovenSetpoint'],
+    'powerConsumptionReport': ['powerConsumption'],
     'powerMeter': ['power'],
     'powerSource': ['powerSource'],
     'presenceSensor': ['presence'],
@@ -116,6 +121,7 @@ class Capability:
     color_control = 'colorControl'
     color_temperature = 'colorTemperature'
     contact_sensor = 'contactSensor'
+    demand_response_load_control = 'demandResponseLoadControl'
     dishwasher_mode = 'dishwasherMode'
     dishwasher_operating_state = 'dishwasherOperatingState'
     door_control = 'doorControl'
@@ -125,6 +131,7 @@ class Capability:
     energy_meter = 'energyMeter'
     equivalent_carbon_dioxide_measurement = \
         'equivalentCarbonDioxideMeasurement'
+    execute = 'execute'
     fan_speed = 'fanSpeed'
     filter_status = 'filterStatus'
     formaldehyde_measurement = 'formaldehydeMeasurement'
@@ -137,10 +144,12 @@ class Capability:
     media_playback_repeat = 'mediaPlaybackRepeat'
     media_playback_shuffle = 'mediaPlaybackShuffle'
     motion_sensor = 'motionSensor'
+    ocf = 'ocf'
     odor_sensor = 'odorSensor'
     oven_mode = 'ovenMode'
     oven_operating_state = 'ovenOperatingState'
     oven_setpoint = 'ovenSetpoint'
+    power_consumption_report = 'powerConsumptionReport'
     power_meter = 'powerMeter'
     power_source = 'powerSource'
     presence_sensor = 'presenceSensor'
@@ -195,9 +204,13 @@ class Attribute:
     contact = 'contact'
     cooling_setpoint = 'coolingSetpoint'
     cooling_setpoint_range = 'coolingSetpointRange'
+    data = 'data'
+    di = 'di'
     dishwasher_job_state = 'dishwasherJobState'
     dishwasher_mode = 'dishwasherMode'
+    dmv = 'dmv'
     door = 'door'
+    drlc_status = 'drlcStatus'
     dryer_job_state = 'dryerJobState'
     dryer_mode = 'dryerMode'
     dust_level = 'dustLevel'
@@ -212,6 +225,7 @@ class Attribute:
     heating_setpoint_range = 'heatingSetpointRange'
     hue = 'hue'
     humidity = 'humidity'
+    icv = 'icv'
     illuminance = 'illuminance'
     infrared_level = 'infraredLevel'
     input_source = 'inputSource'
@@ -220,18 +234,30 @@ class Attribute:
     lock = 'lock'
     lqi = 'lqi'
     machine_state = 'machineState'
+    mndt = 'mndt'
+    mnfv = 'mnfv'
+    mnhw = 'mnhw'
+    mnml = 'mnml'
+    mnmn = 'mnmn'
+    mnmo = 'mnmo'
+    mnos = 'mnos'
+    mnpv = 'mnpv'
+    mnsl = 'mnsl'
     motion = 'motion'
     mute = 'mute'
+    n = 'n'
     number_of_buttons = 'numberOfButtons'
     odor_level = 'odorLevel'
     operation_time = 'operationTime'
     oven_job_state = 'ovenJobState'
     oven_mode = 'ovenMode'
     oven_setpoint = 'ovenSetpoint'
+    pi = 'pi'
     playback_repeat_mode = 'playbackRepeatMode'
     playback_shuffle = 'playbackShuffle'
     playback_status = 'playbackStatus'
     power = 'power'
+    power_consumption = 'powerConsumption'
     power_source = 'powerSource'
     presence = 'presence'
     progress = 'progress'
@@ -245,6 +271,7 @@ class Attribute:
     schedule = 'schedule'
     smoke = 'smoke'
     sound = 'sound'
+    st = 'st'
     supported_button_values = 'supportedButtonValues'
     supported_input_sources = 'supportedInputSources'
     supported_machine_states = 'supportedMachineStates'
@@ -263,6 +290,7 @@ class Attribute:
     tvoc_level = 'tvocLevel'
     ultraviolet_index = 'ultravioletIndex'
     valve = 'valve'
+    vid = 'vid'
     voltage = 'voltage'
     volume = 'volume'
     washer_job_state = 'washerJobState'

--- a/pysmartthings/const.py
+++ b/pysmartthings/const.py
@@ -1,4 +1,4 @@
 """Define consts for the pysmartthings package."""
 
 __title__ = "pysmartthings"
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -34,21 +34,24 @@ class Command:
     """Define common commands."""
 
     close = 'close'
-    off = 'off'
+    execute = 'execute'
     lock = 'lock'
+    off = 'off'
     open = 'open'
     on = 'on'
+    override_drlc_action = 'overrideDrlcAction'
     preset_position = 'presetPosition'
+    request_drlc_action = 'requestDrlcAction'
     set_color = 'setColor'
     set_color_temperature = 'setColorTemperature'
-    set_fan_speed = 'setFanSpeed'
     set_cooling_setpoint = 'setCoolingSetpoint'
+    set_fan_speed = 'setFanSpeed'
     set_heating_setpoint = 'setHeatingSetpoint'
     set_hue = 'setHue'
     set_level = 'setLevel'
+    set_saturation = 'setSaturation'
     set_thermostat_fan_mode = 'setThermostatFanMode'
     set_thermostat_mode = 'setThermostatMode'
-    set_saturation = 'setSaturation'
     unlock = 'unlock'
 
 

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -452,17 +452,17 @@ class DeviceStatusBase:
     def ocf_system_time(self) -> Optional[str]:
         """Get the OCF system time."""
         return self._attributes[Attribute.st].value
-    
+
     @property
     def ocf_firmware_version(self) -> Optional[str]:
         """Get the OCF firmware version."""
         return self._attributes[Attribute.mnfv].value
-    
+
     @property
     def ocf_date_of_manufacture(self) -> Optional[str]:
         """Get the OCF date of manufacture."""
         return self._attributes[Attribute.mndt].value
-    
+
     @property
     def ocf_hardware_version(self) -> Optional[str]:
         """Get the OCF hardware version."""

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -374,6 +374,165 @@ class DeviceStatusBase:
         """Get the windowShade attribute."""
         return self._attributes[Attribute.window_shade].value
 
+    @property
+    def drlc_status(self) -> Optional[dict]:
+        """Get the demand response load control status."""
+        return self._attributes[Attribute.drlc_status].value
+
+    @property
+    def drlc_status_duration(self) -> Optional[int]:
+        """Get the duration component of the drlc status."""
+        try:
+            return int(self.drlc_status['duration'])
+        except (KeyError, ValueError, TypeError):
+            return None
+
+    @property
+    def drlc_status_level(self) -> Optional[int]:
+        """Get the level component of the drlc status."""
+        try:
+            return int(self.drlc_status['drlcLevel'])
+        except (KeyError, ValueError, TypeError):
+            return None
+
+    @property
+    def drlc_status_start(self) -> Optional[str]:
+        """Get the level component of the drlc status."""
+        try:
+            return self.drlc_status['start']
+        except (KeyError, TypeError):
+            return None
+
+    @property
+    def drlc_status_override(self) -> Optional[bool]:
+        """Get the override component of the drlc status."""
+        try:
+            return bool(self.drlc_status['override'])
+        except (KeyError, ValueError, TypeError):
+            return None
+
+    @property
+    def power_consumption(self) -> Optional[dict]:
+        """Get the power consumption report data."""
+        return self._attributes[Attribute.power_consumption].value
+
+    @property
+    def power_consumption_start(self) -> Optional[str]:
+        """Get the start component of power consumption data."""
+        try:
+            return self.power_consumption['start']
+        except (KeyError, TypeError):
+            return None
+
+    @property
+    def power_consumption_power(self) -> Optional[int]:
+        """Get the power component of power consumption data."""
+        try:
+            return int(self.power_consumption['power'])
+        except (KeyError, ValueError, TypeError):
+            return None
+
+    @property
+    def power_consumption_energy(self) -> Optional[int]:
+        """Get the energy component of power consumption data."""
+        try:
+            return int(self.power_consumption['energy'])
+        except (KeyError, ValueError, TypeError):
+            return None
+
+    @property
+    def power_consumption_end(self) -> Optional[str]:
+        """Get the end component of power consumption data."""
+        try:
+            return self.power_consumption['end']
+        except (KeyError, TypeError):
+            return None
+
+    @property
+    def ocf_system_time(self) -> Optional[str]:
+        """Get the OCF system time."""
+        return self._attributes[Attribute.st].value
+    
+    @property
+    def ocf_firmware_version(self) -> Optional[str]:
+        """Get the OCF firmware version."""
+        return self._attributes[Attribute.mnfv].value
+    
+    @property
+    def ocf_date_of_manufacture(self) -> Optional[str]:
+        """Get the OCF date of manufacture."""
+        return self._attributes[Attribute.mndt].value
+    
+    @property
+    def ocf_hardware_version(self) -> Optional[str]:
+        """Get the OCF hardware version."""
+        return self._attributes[Attribute.mnhw].value
+
+    @property
+    def ocf_device_id(self) -> Optional[str]:
+        """Get the OCF device id."""
+        return self._attributes[Attribute.di].value
+
+    @property
+    def ocf_support_link(self) -> Optional[str]:
+        """Get the OCF support link."""
+        return self._attributes[Attribute.mnsl].value
+
+    @property
+    def ocf_data_model_version(self) -> Optional[str]:
+        """Get the OCF data model version."""
+        return self._attributes[Attribute.dmv].value
+
+    @property
+    def ocf_name(self) -> Optional[str]:
+        """Get the OCF name."""
+        return self._attributes[Attribute.n].value
+
+    @property
+    def ocf_vendor_id(self) -> Optional[str]:
+        """Get the OCF vendor id."""
+        return self._attributes[Attribute.vid].value
+
+    @property
+    def ocf_model_number(self):
+        """Get the OCF model number."""
+        return self._attributes[Attribute.mnmo].value
+
+    @property
+    def ocf_manufacturer_name(self) -> Optional[str]:
+        """Get the OCF manufacturer name."""
+        return self._attributes[Attribute.mnmn].value
+
+    @property
+    def ocf_manufacturer_details_link(self) -> Optional[str]:
+        """Get the OCF manufacturer details link."""
+        return self._attributes[Attribute.mnml].value
+
+    @property
+    def ocf_platform_version(self) -> Optional[str]:
+        """Get the OCF platform version."""
+        return self._attributes[Attribute.mnpv].value
+
+    @property
+    def ocf_os_version(self) -> Optional[str]:
+        """Get the OCF OS version."""
+        return self._attributes[Attribute.mnos].value
+
+    @property
+    def ocf_platform_id(self) -> Optional[str]:
+        """Get the OCF platform id."""
+        return self._attributes[Attribute.pi].value
+
+    @property
+    def ocf_spec_version(self) -> Optional[str]:
+        """Get the OCF spec version."""
+        return self._attributes[Attribute.icv].value
+
+    @property
+    def data(self) -> Optional[dict]:
+        """Get the data attribute."""
+        return self._attributes[Attribute.data].value
+
 
 class DeviceStatus(DeviceStatusBase):
     """Define the device status."""

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,9 @@
-coveralls==1.5.1
-flake8==3.7.4
+coveralls==1.6.0
+flake8==3.7.7
 flake8-docstrings==1.3.0
 pydocstyle==3.0.0
-pylint==2.2.2
-pytest==4.2.0
+pylint==2.3.0
+pytest==4.3.0
 pytest-asyncio==0.10.0
 pytest-cov==2.6.1
 pytest-timeout==1.3.3

--- a/tests/json/device_command_post_execute.json
+++ b/tests/json/device_command_post_execute.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    {
+      "component": "main",
+      "capability": "execute",
+      "command": "execute",
+      "arguments": ["Test", {"data": "Test"}]
+    }
+  ]
+}

--- a/tests/json/device_command_post_override_drlc_action.json
+++ b/tests/json/device_command_post_override_drlc_action.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    {
+      "component": "main",
+      "capability": "demandResponseLoadControl",
+      "command": "overrideDrlcAction",
+      "arguments": [true]
+    }
+  ]
+}

--- a/tests/json/device_command_post_request_drlc_action.json
+++ b/tests/json/device_command_post_request_drlc_action.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    {
+      "component": "main",
+      "capability": "demandResponseLoadControl",
+      "command": "requestDrlcAction",
+      "arguments": [1, 2, "1970-01-01T00:00:00Z", 10, 1]
+    }
+  ]
+}

--- a/tests/json/device_samsungac_status.json
+++ b/tests/json/device_samsungac_status.json
@@ -1,0 +1,121 @@
+{
+  "components": {
+    "main": {
+      "demandResponseLoadControl": {
+        "drlcStatus": {
+          "value": {
+            "duration": 0,
+            "drlcLevel": -1,
+            "start": "1970-01-01T00:00:00Z",
+            "override": false
+          }
+        }
+      },
+      "powerConsumptionReport": {
+        "powerConsumption": {
+          "value": {
+            "start": "2019-02-24T21:03:04Z",
+            "power": 0,
+            "energy": 500,
+            "end": "2019-02-26T02:05:55Z"
+          }
+        }
+      },
+      "ocf": {
+        "st": {
+          "value": "02:05:55Z"
+        },
+        "mnfv": {
+          "value": "0.1.0"
+        },
+        "mndt": {
+          "value": "2019-02-26T02:05:55Z"
+        },
+        "mnhw": {
+          "value": "1.0"
+        },
+        "di": {
+          "value": "743de49f-036f-4e9c-839a-2f89d57607db"
+        },
+        "mnsl": {
+          "value": "http://www.samsung.com/support"
+        },
+        "dmv": {
+          "value": "res.1.1.0,sh.1.1.0"
+        },
+        "n": {
+          "value": "Air Conditioner"
+        },
+        "vid": {
+          "value": "DA-AC-RAC-000001"
+        },
+        "mnmo": {
+          "value": "ARTIK051_KRAC_18K|10193441|60010123001111010200000000000000"
+        },
+        "mnmn": {
+          "value": "Samsung Electronics"
+        },
+        "mnml": {
+          "value": "http://www.samsung.com"
+        },
+        "mnpv": {
+          "value": "0.1.0"
+        },
+        "mnos": {
+          "value": "TizenRT2.0"
+        },
+        "pi": {
+          "value": "d5226d90-1b4f-e59d-5f3f-027ac3b18faf"
+        },
+        "icv": {
+          "value": "core.1.1.0"
+        }
+      },
+      "refresh": {},
+      "temperatureMeasurement": {
+        "temperature": {
+          "value": 22.0,
+          "unit": "C"
+        }
+      },
+      "airConditionerMode": {
+        "airConditionerMode": {
+          "value": "heat"
+        }
+      },
+      "fanSpeed": {
+        "fanSpeed": {
+          "value": 2
+        }
+      },
+      "execute": {
+        "data": {
+          "value": {
+            "payload": {
+              "speed": 2,
+              "if": [
+                "oic.if.baseline",
+                "oic.if.a"
+              ],
+              "direction": "Fix",
+              "rt": [
+                "oic.r.airflow"
+              ]
+            }
+          }
+        }
+      },
+      "thermostatCoolingSetpoint": {
+        "coolingSetpoint": {
+          "value": 23.0,
+          "unit": "C"
+        }
+      },
+      "switch": {
+        "switch": {
+          "value": "on"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1021,7 +1021,7 @@ class TestDeviceStatus:
         assert status.ocf_manufacturer_details_link == 'http://www.samsung.com'
         assert status.ocf_manufacturer_name == 'Samsung Electronics'
         assert status.ocf_model_number == \
-               'ARTIK051_KRAC_18K|10193441|60010123001111010200000000000000'
+            'ARTIK051_KRAC_18K|10193441|60010123001111010200000000000000'
         assert status.ocf_name == 'Air Conditioner'
         assert status.ocf_os_version == 'TizenRT2.0'
         assert status.ocf_platform_id == 'd5226d90-1b4f-e59d-5f3f-027ac3b18faf'

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -952,6 +952,7 @@ class TestDeviceStatus:
         status.update_attribute_value(Attribute.lock, 'locked')
         status.update_attribute_value(Attribute.door, 'open')
         status.update_attribute_value(Attribute.window_shade, 'closed')
+        status.update_attribute_value(Attribute.data, {'test': 'test'})
         # Act/Assert
         assert status.humidity == 50
         assert status.temperature == 55
@@ -961,3 +962,109 @@ class TestDeviceStatus:
         assert status.lock == 'locked'
         assert status.door == 'open'
         assert status.window_shade == 'closed'
+        assert status.data == {'test': 'test'}
+
+    @staticmethod
+    def test_well_known_ocf_attributes():
+        """Tests the OCF related attributes."""
+        # Arrange
+        data = get_json('device_samsungac_status.json')
+        status = DeviceStatus(None, device_id=DEVICE_ID, data=data)
+        # Act/Assert
+        assert status.ocf_data_model_version == 'res.1.1.0,sh.1.1.0'
+        assert status.ocf_date_of_manufacture == '2019-02-26T02:05:55Z'
+        assert status.ocf_device_id == DEVICE_ID
+        assert status.ocf_firmware_version == '0.1.0'
+        assert status.ocf_hardware_version == '1.0'
+        assert status.ocf_manufacturer_details_link == 'http://www.samsung.com'
+        assert status.ocf_manufacturer_name == 'Samsung Electronics'
+        assert status.ocf_model_number == \
+               'ARTIK051_KRAC_18K|10193441|60010123001111010200000000000000'
+        assert status.ocf_name == 'Air Conditioner'
+        assert status.ocf_os_version == 'TizenRT2.0'
+        assert status.ocf_platform_id == 'd5226d90-1b4f-e59d-5f3f-027ac3b18faf'
+        assert status.ocf_platform_version == '0.1.0'
+        assert status.ocf_spec_version == 'core.1.1.0'
+        assert status.ocf_support_link == 'http://www.samsung.com/support'
+        assert status.ocf_system_time == '02:05:55Z'
+        assert status.ocf_vendor_id == 'DA-AC-RAC-000001'
+
+    @staticmethod
+    def test_well_known_drlc_attributes():
+        """Tests the drlc related attributes."""
+        status = DeviceStatus(None, device_id=DEVICE_ID)
+        # No attribute
+        assert status.drlc_status is None
+        assert status.drlc_status_duration is None
+        assert status.drlc_status_level is None
+        assert status.drlc_status_override is None
+        assert status.drlc_status_start is None
+        # Populated
+        drlc_status = {
+            "duration": 0,
+            "drlcLevel": -1,
+            "start": "1970-01-01T00:00:00Z",
+            "override": False
+        }
+        status.update_attribute_value(Attribute.drlc_status, drlc_status)
+        assert status.drlc_status == drlc_status
+        assert status.drlc_status_duration == 0
+        assert status.drlc_status_level == -1
+        assert not status.drlc_status_override
+        assert status.drlc_status_start == '1970-01-01T00:00:00Z'
+        # Missing
+        status.update_attribute_value(Attribute.drlc_status, {})
+        assert status.drlc_status == {}
+        assert status.drlc_status_duration is None
+        assert status.drlc_status_level is None
+        assert status.drlc_status_override is None
+        assert status.drlc_status_start is None
+        # Not valid
+        drlc_status = {
+            "duration": 'Foo',
+            "drlcLevel": 'Foo'
+        }
+        status.update_attribute_value(Attribute.drlc_status, drlc_status)
+        assert status.drlc_status == drlc_status
+        assert status.drlc_status_duration is None
+        assert status.drlc_status_level is None
+
+    @staticmethod
+    def test_well_known_power_consumption_attributes():
+        """Tests the power consumption related attributes."""
+        status = DeviceStatus(None, device_id=DEVICE_ID)
+        # No attribute
+        assert status.power_consumption is None
+        assert status.power_consumption_end is None
+        assert status.power_consumption_energy is None
+        assert status.power_consumption_power is None
+        assert status.power_consumption_start is None
+        # Populated
+        data = {
+            "start": "2019-02-24T21:03:04Z",
+            "power": 0,
+            "energy": 500,
+            "end": "2019-02-26T02:05:55Z"
+        }
+        status.update_attribute_value(Attribute.power_consumption, data)
+        assert status.power_consumption == data
+        assert status.power_consumption_end == '2019-02-26T02:05:55Z'
+        assert status.power_consumption_energy == 500
+        assert status.power_consumption_power == 0
+        assert status.power_consumption_start == '2019-02-24T21:03:04Z'
+        # Missing
+        status.update_attribute_value(Attribute.power_consumption, {})
+        assert status.power_consumption == {}
+        assert status.power_consumption_end is None
+        assert status.power_consumption_energy is None
+        assert status.power_consumption_power is None
+        assert status.power_consumption_start is None
+        # Not valid
+        data = {
+            "power": "Foo",
+            "energy": "Bar"
+        }
+        status.update_attribute_value(Attribute.power_consumption, data)
+        assert status.power_consumption == data
+        assert status.power_consumption_energy is None
+        assert status.power_consumption_power is None

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -709,6 +709,48 @@ class TestDeviceEntity:
 
     @staticmethod
     @pytest.mark.asyncio
+    async def test_request_drlc_action(api):
+        """Tests the request_drlc_action method."""
+        # Arrange
+        device = DeviceEntity(api, device_id=DEVICE_ID)
+        # Act/Assert
+        assert await device.request_drlc_action(
+            1, 2, '1970-01-01T00:00:00Z', 10, 1)
+        assert device.status.drlc_status is None
+        assert await device.request_drlc_action(
+            1, 2, '1970-01-01T00:00:00Z', 10, 1, set_status=True)
+        assert device.status.drlc_status == {
+            "duration": 10,
+            "drlcLevel": 2,
+            "start": '1970-01-01T00:00:00Z',
+            "override": False
+        }
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_override_drlc_action(api):
+        """Tests the override_drlc_action method."""
+        # Arrange
+        device = DeviceEntity(api, device_id=DEVICE_ID)
+        # Act/Assert
+        assert await device.override_drlc_action(True)
+        assert device.status.drlc_status is None
+        assert await device.override_drlc_action(True, set_status=True)
+        assert device.status.drlc_status == {
+            "override": True
+        }
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_execute(api):
+        """Tests the execute method."""
+        # Arrange
+        device = DeviceEntity(api, device_id=DEVICE_ID)
+        # Act/Assert
+        assert await device.execute('Test', {'data': 'Test'})
+
+    @staticmethod
+    @pytest.mark.asyncio
     async def test_preset_position(api):
         """Tests the preset_position method."""
         # Arrange


### PR DESCRIPTION
## Description:
- Adds support and well-known attributes/methods for the following capabilities: `demandResponseLoadControl`, `execute`, `ocf`, and `powerConsumptionReport` found in Samsung Air Conditioners.
- Update test dependencies
 
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed