### PR TITLE
v0.6.5

### DIFF
--- a/pysmartthings/const.py
+++ b/pysmartthings/const.py
@@ -1,4 +1,4 @@
 """Define consts for the pysmartthings package."""
 
 __title__ = "pysmartthings"
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -42,6 +42,7 @@ class Command:
     override_drlc_action = 'overrideDrlcAction'
     preset_position = 'presetPosition'
     request_drlc_action = 'requestDrlcAction'
+    set_air_conditioner_mode = 'setAirConditionerMode'
     set_color = 'setColor'
     set_color_temperature = 'setColorTemperature'
     set_cooling_setpoint = 'setCoolingSetpoint'
@@ -533,6 +534,11 @@ class DeviceStatusBase:
         """Get the data attribute."""
         return self._attributes[Attribute.data].value
 
+    @property
+    def air_conditioner_mode(self) -> Optional[str]:
+        """Get the air conditioner mode attribute."""
+        return self._attributes[Attribute.air_conditioner_mode].value
+
 
 class DeviceStatus(DeviceStatusBase):
     """Define the device status."""
@@ -905,6 +911,17 @@ class DeviceEntity(Entity, Device):
             command_args.append(args)
         return await self.command(component_id, Capability.execute,
                                   Command.execute, command_args)
+
+    async def set_air_conditioner_mode(
+            self, mode: str, *, set_status: bool = False,
+            component_id: str = 'main'):
+        """Call the set air conditioner mode command."""
+        result = self.command(component_id, Capability.air_conditioner_mode,
+                              Command.set_air_conditioner_mode, [mode])
+        if result and set_status:
+            self.status.update_attribute_value(
+                Attribute.air_conditioner_mode, mode)
+        return result
 
     @property
     def status(self):

--- a/tests/json/device_command_post_set_air_conditioner_mode.json
+++ b/tests/json/device_command_post_set_air_conditioner_mode.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    {
+      "component": "main",
+      "capability": "airConditionerMode",
+      "command": "setAirConditionerMode",
+      "arguments": ["auto"]
+    }
+  ]
+}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -758,6 +758,18 @@ class TestDeviceEntity:
         # Act/Assert
         assert await device.preset_position()
 
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_set_air_conditioner_mode(api):
+        """Tests the set_air_conditioner_mode method."""
+        # Arrange
+        device = DeviceEntity(api, device_id=DEVICE_ID)
+        # Act/Assert
+        assert await device.set_air_conditioner_mode('auto')
+        assert device.status.air_conditioner_mode is None
+        assert await device.set_air_conditioner_mode('auto', set_status=True)
+        assert device.status.air_conditioner_mode == 'auto'
+
 
 class TestDeviceStatus:
     """Tests for the DeviceStatus class."""


### PR DESCRIPTION
## Description:
- Add well-known attribute and command for the `airConditionerMode` capability

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed