### PR TITLE
Support gas meter capability and attribute

### DIFF
--- a/pysmartthings/capability.py
+++ b/pysmartthings/capability.py
@@ -48,6 +48,14 @@ CAPABILITIES_TO_ATTRIBUTES = {
     "filterStatus": ["filterStatus"],
     "formaldehydeMeasurement": ["formaldehydeLevel"],
     "garageDoorControl": ["door"],
+    "gasMeter": [
+        "gasMeter",
+        "gasMeterCalorific",
+        "gasMeterConversion",
+        "gasMeterPrecision",
+        "gasMeterTime",
+        "gasMeterVolume",
+    ],
     "illuminanceMeasurement": ["illuminance"],
     "infraredLevel": ["infraredLevel"],
     "lock": ["lock"],
@@ -183,6 +191,12 @@ class Capability:
     filter_status = "filterStatus"
     formaldehyde_measurement = "formaldehydeMeasurement"
     garage_door_control = "garageDoorControl"
+    gas_meter = "gasMeter"
+    gas_meter_calorific = "gasMeterCalorific"
+    gas_meter_conversion = "gasMeterConversion"
+    gas_meter_precision = "gasMeterPrecision"
+    gas_meter_time = "gasMeterTime"
+    gas_meter_volume = "gasMeterVolume"
     illuminance_measurement = "illuminanceMeasurement"
     infrared_level = "infraredLevel"
     lock = "lock"
@@ -270,6 +284,7 @@ class Attribute:
     filter_status = "filterStatus"
     fine_dust_level = "fineDustLevel"
     formaldehyde_level = "formaldehydeLevel"
+    gas_meter = "gasMeter"
     heating_setpoint = "heatingSetpoint"
     heating_setpoint_range = "heatingSetpointRange"
     hue = "hue"


### PR DESCRIPTION
## Description:
This exposes attributes and capabilities for the gas meter readings which are provided as part of the SmartThings integration with Bulb energy meters (https://www.samsung.com/uk/smartenergy/)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `pytest`
  - [x] There is no commented out code in this PR.

## Sample test code

https://gist.github.com/javache/b619b9623970104382848d91084d78a0

outputs:

```
# print(device.name)
smartthings-energy-control-bulb

# print(device.label)
Bulb Energy Meter

# print(device.capabilities)
['gasMeter', 'energyMeter', 'healthCheck']

# await device.status.refresh()

# print(dict(device.status.attributes))
{
   'energy': status(value=2212.724, unit='kWh', data=None),
   'checkInterval': status(value=600, unit='s', data={'deviceScheme': 'TRACKED', 'protocol': 'unknown'}),
   'healthStatus': status(value=None, unit=None, data={}),
   'DeviceWatch-Enroll': status(value={'protocol': 'cloud', 'scheme': 'TRACKED'}, unit=None, data=None),
   'DeviceWatch-DeviceStatus': status(value=None, unit=None, data={}),
   'gasMeterPrecision': status(value=None, unit=None, data=None),
   'gasMeterCalorific': status(value=None, unit=None, data=None),
   'gasMeterTime': status(value=None, unit=None, data=None),
   'gasMeterVolume': status(value=None, unit='m^3', data=None),
   'gasMeterConversion': status(value=None, unit=None, data=None),
   'gasMeter': status(value=13550.687, unit='kWh', data=None)
}

# for cap in device.capabilities:
#   if cap in CAPABILITIES_TO_ATTRIBUTES:
#     for attr in CAPABILITIES_TO_ATTRIBUTES[cap]:
#       print('%s/%s = %s' % (cap, attr, device.status.attributes[attr]))
gasMeter/gasMeterPrecision = status(value=None, unit=None, data=None)
gasMeter/gasMeterCalorific = status(value=None, unit=None, data=None)
gasMeter/gasMeterTime = status(value=None, unit=None, data=None)
gasMeter/gasMeterVolume = status(value=None, unit='m^3', data=None)
gasMeter/gasMeterConversion = status(value=None, unit=None, data=None)
gasMeter/gasMeter = status(value=13550.687, unit='kWh', data=None)
energyMeter/energy = status(value=2212.724, unit='kWh', data=None)

# print(device.status.attributes[Attribute.gas_meter])
status(value=13550.687, unit='kWh', data=None)