### PR TITLE
Exclude tests from installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author="Andrew Sayre",
     author_email="andrew@sayre.net",
     license="ASL 2.0",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests*",)),
     install_requires=["aiohttp>=3.5.1,<4.0.0"],
     tests_require=["tox>=3.5.0,<4.0.0"],
     platforms=["any"],


### PR DESCRIPTION
## Description:

Installing tests is not generally desirable in the first place, but particularly not in the global top level `tests` package.

**Related issue (if applicable):** fixes #<pysmartthings issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
  - [ ] `README.MD` updated (if necessary)