### PR TITLE
Add additional Power Consumption Attributes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -8,11 +8,9 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 indent = "    "
-# by default isort don't check module indexes
-not_skip = __init__.py
 # will group `import x` and `from x import` of the same module.
 force_sort_within_sections = true
-sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 default_section = THIRDPARTY
 known_first_party = pyheos,tests
 forced_separate = tests

--- a/lint.cmd
+++ b/lint.cmd
@@ -1,5 +1,5 @@
 @echo off
-isort tests pysmartthings --recursive
+isort tests pysmartthings
 black tests pysmartthings
 pylint tests pysmartthings
 flake8 tests pysmartthings

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -447,7 +447,7 @@ class DeviceStatusBase:
 
     @property
     def power_consumption_start(self) -> Optional[str]:
-        """Get the start component of power consumption data."""
+        """Get the start date of the reporting period in Iso8601Date format."""
         try:
             return self.power_consumption["start"]
         except (KeyError, TypeError):
@@ -455,26 +455,58 @@ class DeviceStatusBase:
 
     @property
     def power_consumption_power(self) -> Optional[int]:
-        """Get the power component of power consumption data."""
+        """Get the instantaneous power consumption during the reporting period in watts (W)."""
         try:
             return int(self.power_consumption["power"])
         except (KeyError, ValueError, TypeError):
             return None
 
     @property
-    def power_consumption_energy(self) -> Optional[int]:
-        """Get the energy component of power consumption data."""
+    def power_consumption_energy(self) -> Optional[float]:
+        """Get the accumulated energy consumption during the reporting period in watt-hours (Wh)."""
         try:
-            return int(self.power_consumption["energy"])
+            return float(self.power_consumption["energy"])
         except (KeyError, ValueError, TypeError):
             return None
 
     @property
     def power_consumption_end(self) -> Optional[str]:
-        """Get the end component of power consumption data."""
+        """Get the end date of the reporting period in Iso8601Date format."""
         try:
             return self.power_consumption["end"]
         except (KeyError, TypeError):
+            return None
+
+    @property
+    def power_consumption_delta_energy(self) -> Optional[float]:
+        """Get the delta of accumulated energy consumption during the reporting period in watt-hours (Wh)."""
+        try:
+            return float(self.power_consumption["deltaEnergy"])
+        except (KeyError, TypeError, TypeError):
+            return None
+
+    @property
+    def power_consumption_power_energy(self) -> Optional[float]:
+        """Get the energy consumption during the reporting period calculated from instantaneous power consumption in watt-hours (Wh)."""
+        try:
+            return float(self.power_consumption["powerEnergy"])
+        except (KeyError, TypeError, TypeError):
+            return None
+
+    @property
+    def power_consumption_energy_saved(self) -> Optional[float]:
+        """Get the energy saved during the report period in watt-hours (Wh)."""
+        try:
+            return float(self.power_consumption["energySaved"])
+        except (KeyError, TypeError, TypeError):
+            return None
+
+    @property
+    def power_consumption_persisted_energy(self) -> Optional[str]:
+        """Get the accumulated energy consumption that was saved into device local DB in watt-hours (Wh)."""
+        try:
+            return float(self.power_consumption["persistedEnergy"])
+        except (KeyError, TypeError, TypeError):
             return None
 
     @property

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1584,12 +1584,20 @@ class TestDeviceStatus:
         assert status.power_consumption_energy is None
         assert status.power_consumption_power is None
         assert status.power_consumption_start is None
+        assert status.power_consumption_delta_energy is None
+        assert status.power_consumption_energy_saved is None
+        assert status.power_consumption_persisted_energy is None
+        assert status.power_consumption_power_energy is None
         # Populated
         data = {
             "start": "2019-02-24T21:03:04Z",
             "power": 0,
             "energy": 500,
             "end": "2019-02-26T02:05:55Z",
+            "powerEnergy": 1.5,
+            "persistedEnergy": 100,
+            "energySaved": 50,
+            "deltaEnergy": 25,
         }
         status.update_attribute_value(Attribute.power_consumption, data)
         assert status.power_consumption == data
@@ -1597,6 +1605,10 @@ class TestDeviceStatus:
         assert status.power_consumption_energy == 500
         assert status.power_consumption_power == 0
         assert status.power_consumption_start == "2019-02-24T21:03:04Z"
+        assert status.power_consumption_delta_energy == 25
+        assert status.power_consumption_energy_saved == 50
+        assert status.power_consumption_persisted_energy == 100
+        assert status.power_consumption_power_energy == 1.5
         # Missing
         status.update_attribute_value(Attribute.power_consumption, {})
         assert status.power_consumption == {}
@@ -1604,9 +1616,29 @@ class TestDeviceStatus:
         assert status.power_consumption_energy is None
         assert status.power_consumption_power is None
         assert status.power_consumption_start is None
+        assert status.power_consumption_delta_energy is None
+        assert status.power_consumption_energy_saved is None
+        assert status.power_consumption_persisted_energy is None
+        assert status.power_consumption_power_energy is None
+        # Minimal
+        data = {"deltaEnergy": 0, "power": 0, "energy": 60800}
+        status.update_attribute_value(Attribute.power_consumption, data)
+        assert status.power_consumption == data
+        assert status.power_consumption_end is None
+        assert status.power_consumption_energy == 60800
+        assert status.power_consumption_power == 0
+        assert status.power_consumption_start is None
+        assert status.power_consumption_delta_energy == 0
+        assert status.power_consumption_energy_saved is None
+        assert status.power_consumption_persisted_energy is None
+        assert status.power_consumption_power_energy is None
         # Not valid
         data = {"power": "Foo", "energy": "Bar"}
         status.update_attribute_value(Attribute.power_consumption, data)
         assert status.power_consumption == data
         assert status.power_consumption_energy is None
         assert status.power_consumption_power is None
+        assert status.power_consumption_delta_energy is None
+        assert status.power_consumption_energy_saved is None
+        assert status.power_consumption_persisted_energy is None
+        assert status.power_consumption_power_energy is None

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
 deps =
      -r{toxinidir}/test-requirements.txt
 commands =
-     isort tests pysmartthings --recursive --check-only
+     isort tests pysmartthings --check-only
      black tests pysmartthings --check --fast --quiet
      pylint pysmartthings tests
      flake8 tests pysmartthings --doctests


### PR DESCRIPTION
## Description:
- Adds the missing power consumption report attributes
- Fixes `isort` configuration

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
  - [X] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
  - [X] `README.MD` updated (if necessary)