### PR TITLE
Adding ability to get the device health as part of the device status object

### DIFF
--- a/pysmartthings/api.py
+++ b/pysmartthings/api.py
@@ -15,6 +15,7 @@ API_ROOM = "locations/{location_id}/rooms/{room_id}"
 API_DEVICES = "devices"
 API_DEVICE = API_DEVICES + "/{device_id}"
 API_DEVICE_STATUS = "devices/{device_id}/status"
+API_DEVICE_HEALTH = "devices/{device_id}/health"
 API_DEVICE_COMMAND = "devices/{device_id}/commands"
 API_APPS = "apps"
 API_APP = "apps/{app_id}"
@@ -123,6 +124,10 @@ class Api:
     async def get_device_status(self, device_id: str) -> dict:
         """Get the status of a specific device."""
         return await self.get(API_DEVICE_STATUS.format(device_id=device_id))
+    
+    async def get_device_health(self, device_id: str) -> dict:
+        """Get the health of a specific device."""
+        return await self.get(API_DEVICE_HEALTH.format(device_id=device_id))
 
     async def post_device_command(
         self, device_id, component_id, capability, command, args

--- a/pysmartthings/api.py
+++ b/pysmartthings/api.py
@@ -124,7 +124,7 @@ class Api:
     async def get_device_status(self, device_id: str) -> dict:
         """Get the status of a specific device."""
         return await self.get(API_DEVICE_STATUS.format(device_id=device_id))
-    
+
     async def get_device_health(self, device_id: str) -> dict:
         """Get the health of a specific device."""
         return await self.get(API_DEVICE_HEALTH.format(device_id=device_id))

--- a/pysmartthings/const.py
+++ b/pysmartthings/const.py
@@ -1,7 +1,7 @@
 """Define consts for the pysmartthings package."""
 
 __title__ = "pysmartthings"
-__version__ = "0.7.6"
+__version__ = "0.7.7"
 
 # Constants for Health
 HEALTH_API_STATE = "state"

--- a/pysmartthings/const.py
+++ b/pysmartthings/const.py
@@ -4,10 +4,10 @@ __title__ = "pysmartthings"
 __version__ = "0.7.6"
 
 # Constants for Health
-HEALTH_API_STATE='state'
-HEALTH_PACKAGE_STATE='state'
-HEALTH_API_LAST_UPDATE='lastUpdatedDate'
-HEALTH_PACKAGE_LAST_UPDATE='lastUpdatedDate'
+HEALTH_API_STATE = "state"
+HEALTH_PACKAGE_STATE = "state"
+HEALTH_API_LAST_UPDATE = "lastUpdatedDate"
+HEALTH_PACKAGE_LAST_UPDATE = "lastUpdatedDate"
 HEALTH_ATTRIBUTE_MAP = {
     HEALTH_API_STATE: HEALTH_PACKAGE_STATE,
     HEALTH_API_LAST_UPDATE: HEALTH_PACKAGE_LAST_UPDATE,

--- a/pysmartthings/const.py
+++ b/pysmartthings/const.py
@@ -2,3 +2,13 @@
 
 __title__ = "pysmartthings"
 __version__ = "0.7.6"
+
+# Constants for Health
+HEALTH_API_STATE='state'
+HEALTH_PACKAGE_STATE='state'
+HEALTH_API_LAST_UPDATE='lastUpdatedDate'
+HEALTH_PACKAGE_LAST_UPDATE='lastUpdatedDate'
+HEALTH_ATTRIBUTE_MAP = {
+    HEALTH_API_STATE: HEALTH_PACKAGE_STATE,
+    HEALTH_API_LAST_UPDATE: HEALTH_PACKAGE_LAST_UPDATE,
+}

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -725,7 +725,6 @@ class DeviceStatusBase:
         """Get the trackDescription attribute."""
         return self._attributes["trackDescription"].value
     
-    
     @property
     def health(self):
         for attr_map in HEALTH_ATTRIBUTE_MAP.items():

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -727,6 +727,7 @@ class DeviceStatusBase:
 
     @property
     def health(self):
+        """Get the health attribute."""
         for attr_map in HEALTH_ATTRIBUTE_MAP.items():
             if attr_map[1] not in self._health:
                 self._health[attr_map[1]] = None

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 from .api import Api
 from .capability import ATTRIBUTE_OFF_VALUES, ATTRIBUTE_ON_VALUES, Attribute, Capability
-from .entity import Entity
 from .const import HEALTH_ATTRIBUTE_MAP
+from .entity import Entity
 
 DEVICE_TYPE_OCF = "OCF"
 DEVICE_TYPE_DTH = "DTH"

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -808,7 +808,7 @@ class DeviceStatus(DeviceStatusBase):
         """Refresh the values of the entity."""
         data = await self._api.get_device_health(self.device_id)
         for data_key, status_key in HEALTH_ATTRIBUTE_MAP.items():
-            self._health[status_key] = data[data_key]
+            self._health[status_key] = data.get(data_key)
 
 
 class DeviceEntity(Entity, Device):

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -724,7 +724,7 @@ class DeviceStatusBase:
     def media_title(self) -> bool:
         """Get the trackDescription attribute."""
         return self._attributes["trackDescription"].value
-    
+
     @property
     def health(self):
         for attr_map in HEALTH_ATTRIBUTE_MAP.items():
@@ -741,7 +741,7 @@ class DeviceStatus(DeviceStatusBase):
         super().__init__("main")
         self._api = api
         self._device_id = device_id
-        self._components = {} 
+        self._components = {}
         if data:
             self.apply_data(data)
 
@@ -801,7 +801,7 @@ class DeviceStatus(DeviceStatusBase):
         data = await self._api.get_device_status(self.device_id)
         if data:
             self.apply_data(data)
-            
+
     async def refresh_health(self):
         """Refresh the values of the entity."""
         data = await self._api.get_device_health(self.device_id)

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -4,6 +4,8 @@ import colorsys
 import re
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
+from aiohttp import ClientSession
+
 from .api import Api
 from .capability import ATTRIBUTE_OFF_VALUES, ATTRIBUTE_ON_VALUES, Attribute, Capability
 from .const import HEALTH_ATTRIBUTE_MAP
@@ -803,8 +805,10 @@ class DeviceStatus(DeviceStatusBase):
         if data:
             self.apply_data(data)
 
-    async def refresh_health(self):
+    async def refresh_health(self, session: Optional[ClientSession] = None):
         """Refresh the values of the entity."""
+        if session is not None:
+            self._api.session = session
         data = await self._api.get_device_health(self.device_id)
         for data_key, status_key in HEALTH_ATTRIBUTE_MAP.items():
             self._health[status_key] = data.get(data_key)

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -742,8 +742,7 @@ class DeviceStatus(DeviceStatusBase):
         super().__init__("main")
         self._api = api
         self._device_id = device_id
-        self._components = {}
-        
+        self._components = {} 
         if data:
             self.apply_data(data)
 


### PR DESCRIPTION
## Description:
<details of changes goes here>
Adding the device health endpoint to the api and then using that to allow refresh of device health. I've kept the refresh separate to the standard refresh, meaning you can have a different polling frequency. Especially thinking Home Assistant here, so other device refresh will be a webhook, but dont think you get device health via webhook?

This was HA can poll device health  

**Related issue (if applicable):** fixes #<pysmartthings issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
  - [ ] `README.MD` updated (if necessary)