### PR TITLE
Add Samsung Air Free units' specific attributes

### DIFF
--- a/pysmartthings/capability.py
+++ b/pysmartthings/capability.py
@@ -45,6 +45,9 @@ CAPABILITIES_TO_ATTRIBUTES = {
     "equivalentCarbonDioxideMeasurement": ["equivalentCarbonDioxideMeasurement"],
     "execute": ["data"],
     "fanSpeed": ["fanSpeed"],
+    "custom.spiMode": ["spiMode"],
+    "custom.autoCleaningMode": ["autoCleaningMode"],
+    "custom.airConditionerOptionalMode": ["acOptionalMode"],
     "filterStatus": ["filterStatus"],
     "formaldehydeMeasurement": ["formaldehydeLevel"],
     "garageDoorControl": ["door"],
@@ -188,6 +191,9 @@ class Capability:
     equivalent_carbon_dioxide_measurement = "equivalentCarbonDioxideMeasurement"
     execute = "execute"
     fan_speed = "fanSpeed"
+    spi_mode = "custom.spiMode"
+    autoclean_mode = "custom.autoCleaningMode"
+    ac_optional_mode = "custom.airConditionerOptionalMode"
     filter_status = "filterStatus"
     formaldehyde_measurement = "formaldehydeMeasurement"
     garage_door_control = "garageDoorControl"
@@ -274,7 +280,11 @@ class Attribute:
     dust_level = "dustLevel"
     energy = "energy"
     equivalent_carbon_dioxide_measurement = "equivalentCarbonDioxideMeasurement"
+    samsung_options = "x.com.samsung.da.options"
     fan_mode = "fanMode"
+    spi_mode = "spiMode"
+    autoclean_mode = "autoCleaningMode"
+    ac_optional_mode = "acOptionalMode"
     fan_speed = "fanSpeed"
     filter_status = "filterStatus"
     fine_dust_level = "fineDustLevel"


### PR DESCRIPTION
## Description:
Add specific capabilities that Samsung Airfree Units have
(original changes by JRFabbi - https://community.home-assistant.io/t/samsung-air-conditioner/87046/60)

**Related issue (if applicable):** fixes #<pysmartthings issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [ ] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
  - [ ] `README.MD` updated (if necessary)