### PR TITLE
Add fan oscillation mode (valided on my climate)

### DIFF
--- a/pysmartthings/capability.py
+++ b/pysmartthings/capability.py
@@ -44,6 +44,7 @@ CAPABILITIES_TO_ATTRIBUTES = {
     "energyMeter": ["energy"],
     "equivalentCarbonDioxideMeasurement": ["equivalentCarbonDioxideMeasurement"],
     "execute": ["data"],
+    "fanOscillationMode": ["fanOscillationMode", "supportedFanOscillationModes"],
     "fanSpeed": ["fanSpeed"],
     "filterStatus": ["filterStatus"],
     "formaldehydeMeasurement": ["formaldehydeLevel"],
@@ -187,6 +188,7 @@ class Capability:
     energy_meter = "energyMeter"
     equivalent_carbon_dioxide_measurement = "equivalentCarbonDioxideMeasurement"
     execute = "execute"
+    fan_oscillation_mode = "fanOscillationMode"
     fan_speed = "fanSpeed"
     filter_status = "filterStatus"
     formaldehyde_measurement = "formaldehydeMeasurement"
@@ -275,6 +277,7 @@ class Attribute:
     energy = "energy"
     equivalent_carbon_dioxide_measurement = "equivalentCarbonDioxideMeasurement"
     fan_mode = "fanMode"
+    fan_oscillation_mode = "fanOscillationMode"
     fan_speed = "fanSpeed"
     filter_status = "filterStatus"
     fine_dust_level = "fineDustLevel"

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -60,6 +60,7 @@ class Command:
     set_color = "setColor"
     set_color_temperature = "setColorTemperature"
     set_cooling_setpoint = "setCoolingSetpoint"
+    set_fan_oscillation_mode = "setFanOscillationMode"
     set_fan_mode = "setFanMode"
     set_fan_speed = "setFanSpeed"
     set_heating_setpoint = "setHeatingSetpoint"
@@ -612,6 +613,11 @@ class DeviceStatusBase:
     def fan_mode(self) -> Optional[str]:
         """Get the fan mode attribute."""
         return self._attributes[Attribute.fan_mode].value
+
+    @property
+    def fan_oscillation_mode(self) -> Optional[str]:
+        """Get the fan oscillation mode attribute."""
+        return self._attributes[Attribute.fan_oscillation_mode].value
 
     @property
     def supported_ac_fan_modes(self) -> Sequence[str]:
@@ -1180,6 +1186,20 @@ class DeviceEntity(Entity, Device):
         )
         if result and set_status:
             self.status.update_attribute_value(Attribute.fan_mode, mode)
+        return result
+
+    async def set_fan_oscillation_mode(
+        self, mode: str, *, set_status: bool = False, component_id: str = "main"
+    ):
+        """Call the setFanOscillationMode command."""
+        result = await self.command(
+            component_id,
+            Capability.fan_oscillation_mode,
+            Command.set_fan_oscillation_mode,
+            [mode],
+        )
+        if result and set_status:
+            self.status.update_attribute_value(Attribute.fan_oscillation_mode, mode)
         return result
 
     async def set_air_flow_direction(

--- a/tests/json/device_command_post_set_fan_oscillation_mode.json
+++ b/tests/json/device_command_post_set_fan_oscillation_mode.json
@@ -1,0 +1,12 @@
+{
+  "commands": [
+    {
+      "component": "main",
+      "capability": "fanOscillationMode",
+      "command": "setFanOscillationMode",
+      "arguments": [
+        "all"
+      ]
+    }
+  ]
+}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -796,6 +796,18 @@ class TestDeviceEntity:
 
     @staticmethod
     @pytest.mark.asyncio
+    async def test_set_fan_oscillation_mode(api):
+        """Tests the set_fan_oscillation_mode method."""
+        # Arrange
+        device = DeviceEntity(api, device_id=DEVICE_ID)
+        # Act/Assert
+        assert await device.set_fan_oscillation_mode("all")
+        assert device.status.fan_oscillation_mode is None
+        assert await device.set_fan_oscillation_mode("all", set_status=True)
+        assert device.status.fan_oscillation_mode == "all"
+
+    @staticmethod
+    @pytest.mark.asyncio
     async def test_set_air_flow_direction(api):
         """Tests the set_air_flow_direction method."""
         # Arrange
@@ -1495,6 +1507,7 @@ class TestDeviceStatus:
         status.update_attribute_value(Attribute.three_axis, [0, 0, 0])
         status.update_attribute_value(Attribute.supported_ac_modes, ["auto", "cool"])
         status.update_attribute_value(Attribute.fan_mode, "low")
+        status.update_attribute_value(Attribute.fan_oscillation_mode, "fixed")
         status.update_attribute_value(Attribute.supported_ac_fan_modes, ["auto", "low"])
         # Act/Assert
         assert status.humidity == 50


### PR DESCRIPTION
## Description:
Support fan oscillation mode (all, fixed, horizontal, vertical) for climate.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
  - [ ] `README.MD` updated (if necessary)