### PR TITLE
Support ac optional model (valided on my climate)

### DIFF
--- a/pysmartthings/capability.py
+++ b/pysmartthings/capability.py
@@ -7,6 +7,7 @@ https://smartthings.developer.samsung.com/docs/api-ref/capabilities.html
 CAPABILITIES_TO_ATTRIBUTES = {
     "accelerationSensor": ["acceleration"],
     "activityLightingMode": ["lightingMode"],
+    "acOptionalMode": ["custom.airConditionerOptionalMode", "supportedAcOptionalMode"],
     "airConditionerFanMode": ["fanMode", "supportedAcFanModes"],
     "airConditionerMode": ["airConditionerMode", "supportedAcModes"],
     "airFlowDirection": ["airFlowDirection"],
@@ -162,6 +163,7 @@ class Capability:
     activity_lighting_mode = "activityLightingMode"
     air_conditioner_fan_mode = "airConditionerFanMode"
     air_conditioner_mode = "airConditionerMode"
+    air_conditioner_optional_mode = "custom.airConditionerOptionalMode"
     air_flow_direction = "airFlowDirection"
     air_quality_sensor = "airQualitySensor"
     alarm = "alarm"
@@ -246,6 +248,7 @@ class Attribute:
 
     acceleration = "acceleration"
     air_conditioner_mode = "airConditionerMode"
+    air_conditioner_optional_mode = "acOptionalMode"
     air_flow_direction = "airFlowDirection"
     air_quality = "airQuality"
     alarm = "alarm"
@@ -338,6 +341,7 @@ class Attribute:
     st = "st"
     supported_ac_fan_modes = "supportedAcFanModes"
     supported_ac_modes = "supportedAcModes"
+    supported_ac_optional_modes = "supportedAcOptionalMode"
     supported_button_values = "supportedButtonValues"
     supported_input_sources = "supportedInputSources"
     supported_machine_states = "supportedMachineStates"

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -57,6 +57,7 @@ class Command:
     request_drlc_action = "requestDrlcAction"
     set_air_flow_direction = "setAirFlowDirection"
     set_air_conditioner_mode = "setAirConditionerMode"
+    set_air_conditioner_optional_mode = "setAcOptionalMode"
     set_color = "setColor"
     set_color_temperature = "setColorTemperature"
     set_cooling_setpoint = "setCoolingSetpoint"
@@ -603,6 +604,20 @@ class DeviceStatusBase:
     def supported_ac_modes(self) -> Sequence[str]:
         """Get the supported AC modes attribute."""
         value = self._attributes[Attribute.supported_ac_modes].value
+        # pylint: disable=isinstance-second-argument-not-valid-type
+        if isinstance(value, Sequence):
+            return sorted(value)
+        return []
+
+    @property
+    def air_conditioner_optional_mode(self) -> Optional[str]:
+        """Get the air conditioner optional mode attribute."""
+        return self._attributes[Attribute.air_conditioner_optional_mode].value
+
+    @property
+    def supported_ac_optional_modes(self) -> Sequence[str]:
+        """Get the supported AC optional modes attribute."""
+        value = self._attributes[Attribute.supported_ac_optional_modes].value
         # pylint: disable=isinstance-second-argument-not-valid-type
         if isinstance(value, Sequence):
             return sorted(value)
@@ -1166,6 +1181,20 @@ class DeviceEntity(Entity, Device):
         )
         if result and set_status:
             self.status.update_attribute_value(Attribute.air_conditioner_mode, mode)
+        return result
+
+    async def set_air_conditioner_optional_mode(
+        self, mode: str, *, set_status: bool = False, component_id: str = "main"
+    ):
+        """Call the set air conditioner optional mode command."""
+        result = await self.command(
+            component_id,
+            Capability.air_conditioner_optional_mode,
+            Command.set_air_conditioner_optional_mode,
+            [mode],
+        )
+        if result and set_status:
+            self.status.update_attribute_value(Attribute.air_conditioner_optional_mode, mode)
         return result
 
     async def set_fan_mode(

--- a/tests/json/device_command_post_set_air_conditioner_optional_mode.json
+++ b/tests/json/device_command_post_set_air_conditioner_optional_mode.json
@@ -1,0 +1,12 @@
+{
+  "commands": [
+    {
+      "component": "main",
+      "capability": "custom.airConditionerOptionalMode",
+      "command": "setAcOptionalMode",
+      "arguments": [
+        "windFree"
+      ]
+    }
+  ]
+}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -784,6 +784,18 @@ class TestDeviceEntity:
 
     @staticmethod
     @pytest.mark.asyncio
+    async def test_set_air_conditioner_optional_mode(api):
+        """Tests the air_conditioner_optional_mode method."""
+        # Arrange
+        device = DeviceEntity(api, device_id=DEVICE_ID)
+        # Act/Assert
+        assert await device.set_air_conditioner_optional_mode("windFree")
+        assert device.status.air_conditioner_optional_mode is None
+        assert await device.set_air_conditioner_optional_mode("windFree", set_status=True)
+        assert device.status.air_conditioner_optional_mode == "windFree"
+
+    @staticmethod
+    @pytest.mark.asyncio
     async def test_set_fan_mode(api):
         """Tests the set_fan_mode method."""
         # Arrange
@@ -1478,6 +1490,7 @@ class TestDeviceStatus:
 
         assert status.supported_ac_modes == []
         assert status.supported_ac_fan_modes == []
+        assert status.supported_ac_optional_modes == []
 
         status.update_attribute_value(Attribute.humidity, 50)
         status.update_attribute_value(Attribute.temperature, 55)
@@ -1496,6 +1509,7 @@ class TestDeviceStatus:
         status.update_attribute_value(Attribute.supported_ac_modes, ["auto", "cool"])
         status.update_attribute_value(Attribute.fan_mode, "low")
         status.update_attribute_value(Attribute.supported_ac_fan_modes, ["auto", "low"])
+        status.update_attribute_value(Attribute.supported_ac_optional_modes, ["sleep", "windFree"])
         # Act/Assert
         assert status.humidity == 50
         assert status.temperature == 55
@@ -1509,6 +1523,7 @@ class TestDeviceStatus:
         assert status.three_axis == [0, 0, 0]
         assert status.supported_ac_modes == ["auto", "cool"]
         assert status.supported_ac_fan_modes == ["auto", "low"]
+        assert status.supported_ac_optional_modes == ["sleep", "windFree"]
 
     @staticmethod
     def test_well_known_ocf_attributes():


### PR DESCRIPTION
## Description:
Support ac optional mode (off, sleep, windFree, windFreeSleep) for climate.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
  - [ ] `README.MD` updated (if necessary)