### PR TITLE
Add support for `acOptionalMode` (Wind Free AC)

### DIFF
--- a/pysmartthings/capability.py
+++ b/pysmartthings/capability.py
@@ -24,6 +24,7 @@ CAPABILITIES_TO_ATTRIBUTES = {
     "colorControl": ["color", "hue", "saturation"],
     "colorTemperature": ["colorTemperature"],
     "contactSensor": ["contact"],
+    "custom.airConditionerOptionalMode": ["supportedAcOptionalMode", "acOptionalMode"],
     "demandResponseLoadControl": ["drlcStatus"],
     "dishwasherMode": ["dishwasherMode"],
     "dishwasherOperatingState": [
@@ -161,6 +162,7 @@ class Capability:
     acceleration_sensor = "accelerationSensor"
     activity_lighting_mode = "activityLightingMode"
     air_conditioner_fan_mode = "airConditionerFanMode"
+    air_conditioner_optional_mode = "custom.airConditionerOptionalMode"
     air_conditioner_mode = "airConditionerMode"
     air_flow_direction = "airFlowDirection"
     air_quality_sensor = "airQualitySensor"
@@ -246,6 +248,7 @@ class Attribute:
 
     acceleration = "acceleration"
     air_conditioner_mode = "airConditionerMode"
+    ac_optional_mode = "acOptionalMode"
     air_flow_direction = "airFlowDirection"
     air_quality = "airQuality"
     alarm = "alarm"
@@ -338,6 +341,7 @@ class Attribute:
     st = "st"
     supported_ac_fan_modes = "supportedAcFanModes"
     supported_ac_modes = "supportedAcModes"
+    supported_ac_optional_mode = "supportedAcOptionalMode"
     supported_button_values = "supportedButtonValues"
     supported_input_sources = "supportedInputSources"
     supported_machine_states = "supportedMachineStates"

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -57,6 +57,7 @@ class Command:
     request_drlc_action = "requestDrlcAction"
     set_air_flow_direction = "setAirFlowDirection"
     set_air_conditioner_mode = "setAirConditionerMode"
+    set_ac_optional_mode = "setAcOptionalMode"
     set_color = "setColor"
     set_color_temperature = "setColorTemperature"
     set_cooling_setpoint = "setCoolingSetpoint"
@@ -598,6 +599,11 @@ class DeviceStatusBase:
     def air_conditioner_mode(self) -> Optional[str]:
         """Get the air conditioner mode attribute."""
         return self._attributes[Attribute.air_conditioner_mode].value
+
+    @property
+    def ac_optional_mode(self) -> Optional[str]:
+        """Get the air conditioner optional mode attribute."""
+        return self._attributes[Attribute.ac_optional_mode].value
 
     @property
     def supported_ac_modes(self) -> Sequence[str]:
@@ -1166,6 +1172,20 @@ class DeviceEntity(Entity, Device):
         )
         if result and set_status:
             self.status.update_attribute_value(Attribute.air_conditioner_mode, mode)
+        return result
+
+    async def set_ac_optional_mode(
+        self, mode: str, *, set_status: bool = False, component_id: str = "main"
+    ):
+        """Call the set air conditioner mode command."""
+        result = await self.command(
+            component_id,
+            Capability.air_conditioner_optional_mode,
+            Command.set_ac_optional_mode,
+            [mode],
+        )
+        if result and set_status:
+            self.status.update_attribute_value(Attribute.ac_optional_mode, mode)
         return result
 
     async def set_fan_mode(

--- a/pysmartthings/device.py
+++ b/pysmartthings/device.py
@@ -1177,7 +1177,8 @@ class DeviceEntity(Entity, Device):
     async def set_ac_optional_mode(
         self, mode: str, *, set_status: bool = False, component_id: str = "main"
     ):
-        """Call the set air conditioner mode command."""
+        """Call the set air conditioner optional mode command."""
+
         result = await self.command(
             component_id,
             Capability.air_conditioner_optional_mode,

--- a/tests/json/device_command_post_set_ac_optional_mode.json
+++ b/tests/json/device_command_post_set_ac_optional_mode.json
@@ -1,0 +1,12 @@
+{
+  "commands": [
+    {
+      "component": "main",
+      "capability": "custom.airConditionerOptionalMode",
+      "command": "setAcOptionalMode",
+      "arguments": [
+        "windFree"
+      ]
+    }
+  ]
+}

--- a/tests/json/device_samsungac_status.json
+++ b/tests/json/device_samsungac_status.json
@@ -83,6 +83,11 @@
           "value": "heat"
         }
       },
+      "acOptionalMode": {
+        "acOptionalMode": {
+          "value": "smart"
+        }
+      },
       "fanSpeed": {
         "fanSpeed": {
           "value": 2

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -784,6 +784,18 @@ class TestDeviceEntity:
 
     @staticmethod
     @pytest.mark.asyncio
+    async def test_set_ac_optional_mode(api):
+        """Tests the set_ac_optional_mode method."""
+        # Arrange
+        device = DeviceEntity(api, device_id=DEVICE_ID)
+        # Act/Assert
+        assert await device.set_ac_optional_mode("windFree")
+        assert device.status.ac_optional_mode is None
+        assert await device.set_ac_optional_mode("windFree", set_status=True)
+        assert device.status.ac_optional_mode == "windFree"
+
+    @staticmethod
+    @pytest.mark.asyncio
     async def test_set_fan_mode(api):
         """Tests the set_fan_mode method."""
         # Arrange


### PR DESCRIPTION
## Description:
I noticed that the lib didn't had any way of toggling the `wind free` mode on a Samsung Wind Free AC.
That lives inside an attribute `acOptionalMode`.
So I added a property for it and also the set function.
Tested with my AC (reading status and setting a value) and added unit tests.

This is a required change to fix `windfree mode` not available in HA:
https://github.com/home-assistant/core/issues/41884

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
  - [ ] `README.MD` updated (if necessary)