### PR TITLE
Add veryFineDustLevel attribute to dustSensor

### DIFF
--- a/pysmartthings/capability.py
+++ b/pysmartthings/capability.py
@@ -40,7 +40,7 @@ CAPABILITIES_TO_ATTRIBUTES = {
         "dryerJobState",
         "completionTime",
     ],
-    "dustSensor": ["fineDustLevel", "dustLevel"],
+    "dustSensor": ["veryFineDustLevel", "fineDustLevel", "dustLevel"],
     "energyMeter": ["energy"],
     "equivalentCarbonDioxideMeasurement": ["equivalentCarbonDioxideMeasurement"],
     "execute": ["data"],
@@ -368,6 +368,7 @@ class Attribute:
     tvoc_level = "tvocLevel"
     ultraviolet_index = "ultravioletIndex"
     valve = "valve"
+    very_fine_dust_level = "veryFineDustLevel"
     vid = "vid"
     voltage = "voltage"
     volume = "volume"


### PR DESCRIPTION
## Description:

Add the attribute for measuring very fine dust (PM1.0)

https://developer.smartthings.com/docs/devices/capabilities/capabilities-reference/#veryFineDustSensor

## Checklist:

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] Tests have been added/updated and code coverage percentage does not drop. No exclusions in `.coveragerc` allowed
- [x] `README.MD` updated (if necessary)
